### PR TITLE
Remove unused search from install_module

### DIFF
--- a/ooservice/__init__.py
+++ b/ooservice/__init__.py
@@ -117,9 +117,6 @@ class OpenERPService(object):
         module_obj = self.pool.get('ir.module.module')
         with Transaction().start(self.config['db_name']) as txn:
             module_obj.update_list(txn.cursor, txn.user)
-            modules_ids = module_obj.search(txn.cursor,txn.user,[])
-            names = module_obj.read(txn.cursor, txn.user, modules_ids, ['name'])
-            print 'names:{}'.format(names)
             module_ids = module_obj.search(
                 txn.cursor, self.DEFAULT_USER,
                 [('name', '=', module)],


### PR DESCRIPTION
Install module searches for all modules and prints a read from everything.

Removed this part of the code.